### PR TITLE
Duplicate IDs giving bad data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### Version 0.0.8
+Correct problem where genomes with the same gene IDs produced bad results in the Pangenome. 
+
+Report the user-defined names instead of the scientific name.
+
 ### Version 0.0.6
 __Changes__
 - added proper citation to Compute Pangenome and created RELEASE_NOTES.md families

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     perl
 
 module-version:
-    0.0.7
+    0.0.8
 
 owners:
     [dejongh,chenry,janakakbase]

--- a/lib/GenomeComparisonSDK/GenomeComparisonSDKImpl.pm
+++ b/lib/GenomeComparisonSDK/GenomeComparisonSDKImpl.pm
@@ -25,7 +25,6 @@ use Workspace::WorkspaceClient;
 use GenomeAnnotationAPI::GenomeAnnotationAPIClient;
 use Config::IniFiles;
 use JSON::XS;
-use Data::Dumper;
 
 sub function_to_roles{
 	my ($self,$function) = @_;
@@ -524,9 +523,6 @@ sub build_pangenome
     		}
     	}
     }
-
-	print "Length ".length($pangenome->{'orthologs'})."\n";
-	print &Dumper($pangenome);
 	
     my $pg_metadata = $wsClient->save_objects({
 	'workspace' => $workspace_name,


### PR DESCRIPTION
@janakagithub 
PTV-1221  - Genomes that have the same gene IDs give bad results in the Pangenome. For example, two genomes that are numbered gene_1 through gene_N. First, you can't tell which genes come from which genome. Second, if there is a duplicate name gene_X and one is a singleton and the other is part of a homolog family, gene_X will only show up once as a key in the pangenome and it will only be half right, either the singleton family or the homolog family, but not both.

PTV-437 - Report the user-defined names instead of the scientific name. All too often, the scientific name is missing information such as the strain name or it is only approximately correct. The users want to see the results with names that match what they call things in the data panel. It is really pointless to give them output that has all genomes with the same scientific name.